### PR TITLE
Rewrite Source and Destination protocols as Swift 2.0+ Style protocols

### DIFF
--- a/ZoomTransitioning/ZoomTransitionDestinationDelegate.swift
+++ b/ZoomTransitioning/ZoomTransitionDestinationDelegate.swift
@@ -8,10 +8,17 @@
 
 import UIKit
 
-@objc public protocol ZoomTransitionDestinationDelegate: NSObjectProtocol {
+public protocol ZoomTransitionDestinationDelegate {
 
     func transitionDestinationImageViewFrame(forward forward: Bool) -> CGRect
-    optional func transitionDestinationWillBegin()
-    optional func transitionDestinationDidEnd(transitioningImageView imageView: UIImageView)
-    optional func transitionDestinationDidCancel()
+    func transitionDestinationWillBegin()
+    func transitionDestinationDidEnd(transitioningImageView imageView: UIImageView)
+    func transitionDestinationDidCancel()
+}
+
+extension ZoomTransitionDestinationDelegate {
+
+    func transitionDestinationWillBegin() { /* Optional */ }
+    func transitionDestinationDidEnd(transitioningImageView imageView: UIImageView) { /* Optional */ }
+    func transitionDestinationDidCancel() { /* Optional */ }
 }

--- a/ZoomTransitioning/ZoomTransitionSourceDelegate.swift
+++ b/ZoomTransitioning/ZoomTransitionSourceDelegate.swift
@@ -8,11 +8,18 @@
 
 import UIKit
 
-@objc public protocol ZoomTransitionSourceDelegate: NSObjectProtocol {
+public protocol ZoomTransitionSourceDelegate {
 
     func transitionSourceImageView() -> UIImageView
     func transitionSourceImageViewFrame(forward forward: Bool) -> CGRect
-    optional func transitionSourceWillBegin()
-    optional func transitionSourceDidEnd()
-    optional func transitionSourceDidCancel()
+    func transitionSourceWillBegin()
+    func transitionSourceDidEnd()
+    func transitionSourceDidCancel()
+}
+
+extension ZoomTransitionSourceDelegate {
+
+    func transitionSourceWillBegin() { /* Optional */ }
+    func transitionSourceDidEnd() { /* Optional */ }
+    func transitionSourceDidCancel() { /* Optional */ }
 }

--- a/ZoomTransitioning/ZoomTransitioning.swift
+++ b/ZoomTransitioning/ZoomTransitioning.swift
@@ -64,8 +64,8 @@ extension ZoomTransitioning {
         containerView.insertSubview(destinationView, belowSubview: sourceView)
         containerView.addSubview(transitioningImageView)
 
-        source.transitionSourceWillBegin?()
-        destination.transitionDestinationWillBegin?()
+        source.transitionSourceWillBegin()
+        destination.transitionDestinationWillBegin()
 
         UIView.animateWithDuration(
             ZoomTransitioning.transitionDuration,
@@ -81,8 +81,8 @@ extension ZoomTransitioning {
                 transitioningImageView.alpha = 0.0
                 transitioningImageView.removeFromSuperview()
 
-                self.source.transitionSourceDidEnd?()
-                self.destination.transitionDestinationDidEnd?(transitioningImageView: transitioningImageView)
+                self.source.transitionSourceDidEnd()
+                self.destination.transitionDestinationDidEnd(transitioningImageView: transitioningImageView)
 
                 let completed = !transitionContext.transitionWasCancelled()
                 transitionContext.completeTransition(completed)
@@ -106,8 +106,8 @@ extension ZoomTransitioning {
         containerView.insertSubview(sourceView, belowSubview: destinationView)
         containerView.addSubview(transitioningImageView)
 
-        source.transitionSourceWillBegin?()
-        destination.transitionDestinationWillBegin?()
+        source.transitionSourceWillBegin()
+        destination.transitionDestinationWillBegin()
 
         if transitioningImageView.frame.maxY < 0.0 {
             transitioningImageView.frame.origin.y = -transitioningImageView.frame.height
@@ -125,8 +125,8 @@ extension ZoomTransitioning {
                 destinationView.alpha = 1.0
                 transitioningImageView.removeFromSuperview()
 
-                self.source.transitionSourceDidEnd?()
-                self.destination.transitionDestinationDidEnd?(transitioningImageView: transitioningImageView)
+                self.source.transitionSourceDidEnd()
+                self.destination.transitionDestinationDidEnd(transitioningImageView: transitioningImageView)
 
                 let completed = !transitionContext.transitionWasCancelled()
                 transitionContext.completeTransition(completed)


### PR DESCRIPTION
I thought that this might be a more flexible approach for implementing `ZoomTransitionSourceDelegate` and `ZoomTransitionDestinationDelegate` protocols.

Rather than use `@objc` and declare the optional protocol methods explicitly it is more flexible to implement them as swift protocols with default empty implementations.

By doing this the user can implement these protocols on either a `struct` or `class` type in Swift.
Right now the user of this library is forced to use `class` exclusively.
